### PR TITLE
Handle branch names safely in cleanup script

### DIFF
--- a/bin/common/.local/bin/git-cleanup-branches
+++ b/bin/common/.local/bin/git-cleanup-branches
@@ -4,12 +4,12 @@
 
 git fetch --prune &>/dev/null
 
-for branch in $(git branch -vv | grep -o -E '^[\* ]+\S+' | tr -d '* '); do
-  upstream=$(git rev-parse --abbrev-ref --symbolic-full-name "${branch}@{upstream}" 2>/dev/null)
-  if [ -n "${upstream}" ]; then
-    if ! git show-ref --quiet "refs/remotes/${upstream}"; then
-      echo "Deleting branch '${branch}'"
-      git branch -D "${branch}"
+# Use `git for-each-ref` to safely handle branch names with spaces and avoid
+# parsing the output of `git branch`.
+git for-each-ref --format='%(refname:short)\t%(upstream:short)' refs/heads |
+  while IFS=$'\t' read -r branch upstream; do
+    if [ -n "$upstream" ] && ! git show-ref --quiet "refs/remotes/$upstream"; then
+      echo "Deleting branch '$branch'"
+      git branch -D "$branch"
     fi
-  fi
-done
+  done


### PR DESCRIPTION
## Summary
- Improve branch cleanup script to handle names with spaces safely

## Testing
- `bash -n bin/common/.local/bin/git-cleanup-branches`
- `bin/common/.local/bin/git-cleanup-branches`


------
https://chatgpt.com/codex/tasks/task_e_68a15441970c83219b274cc24494746c