### PR TITLE
fix: correct user message in macOS install script

### DIFF
--- a/install/macos/install.sh
+++ b/install/macos/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ "$(id -u)" -eq 0 ]; then
-  echo "The script is running as root, please run as a the user."
+  echo "The script is running as root, please run as the user."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- fix typo in macOS install script user guidance message

## Testing
- `bash -n install/macos/install.sh`
- `shellcheck install/macos/install.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1581496188321ba63551896e0e34d