### PR TITLE
Use fixed string matching in psc

### DIFF
--- a/bin/common/.local/bin/psc
+++ b/bin/common/.local/bin/psc
@@ -4,5 +4,5 @@ cmd="ps axo pid,ppid,user,command"
 if [ "$1" == "" ]; then
   ${cmd}
 else
-  ${cmd} | grep "$1" | grep -v "grep $1" | grep -v "bin/psc"
+  ${cmd} | grep -F "$1" | grep -F -v "grep $1" | grep -v "bin/psc"
 fi


### PR DESCRIPTION
## Summary
- Avoid regex interpretation in the psc utility by using fixed-string `grep -F`

## Testing
- `shellcheck bin/common/.local/bin/psc` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a15813a1788321892e71fbeb532e1e